### PR TITLE
Fix webtop API authorizations

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -144,7 +144,7 @@ buildah add "${container}" imageroot /imageroot
 buildah add "${container}" ui/dist /ui
 # Setup the entrypoint, ask to reserve one TCP port with the label and set a rootless container
 buildah config --entrypoint=/ \
-    --label="org.nethserver.authorizations=traefik@any:routeadm" \
+    --label="org.nethserver.authorizations=traefik@node:routeadm mail@any:mailadm" \
     --label="org.nethserver.tcp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
     --label="org.nethserver.images=${repobase}/webtop-webapp:${IMAGETAG:-latest} \


### PR DESCRIPTION
- Grant routadm on the Traefik instance running on the same node
- Grant mailadm on any Mail instance of the cluster