### PR TITLE
Allow host loopback interface

### DIFF
--- a/imageroot/systemd/user/webtop.service
+++ b/imageroot/systemd/user/webtop.service
@@ -18,6 +18,7 @@ ExecStartPre=/usr/bin/podman pod create \
     --pod-id-file=%t/webtop.pod-id \
     --name=webtop \
     --publish=${TCP_PORT}:8081 \
+    --network=slirp4netns:allow_host_loopback=true \
     --replace
 ExecStart=/usr/bin/podman pod start --pod-id-file %t/webtop.pod-id
 ExecStop=/usr/bin/podman pod stop --ignore --pod-id-file %t/webtop.pod-id -t 10


### PR DESCRIPTION
Map the address 10.0.2.2 in the private network namespace to the host 127.0.0.1. This is necessary to reach the local Ldapproxy instance.

As alternative we could configure the containers with --network=host and bind the services to 127.0.0.1. PosgreSQL should be protected with a random password though. 