### PR TITLE
Make z-push state persistent

### DIFF
--- a/imageroot/actions/import-module/20z-push_legacy_ids
+++ b/imageroot/actions/import-module/20z-push_legacy_ids
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e -o pipefail
+exec 1>&2 # Redirect any output to the journal (stderr)
+
+# Check if the migrated z-push state use the legacy folder ids format
+if [[ -e ./legacy_ids_enabled ]]; then
+	echo "set-env Z_PUSH_USE_LEGACY_FOLDER_IDS True" >&${AGENT_COMFD}
+	rm ./legacy_ids_enabled
+fi

--- a/imageroot/actions/restore-module/06copyenv
+++ b/imageroot/actions/restore-module/06copyenv
@@ -15,4 +15,5 @@ import agent
 
 request = json.load(sys.stdin)
 agent.set_env('MAIL_MODULE_UUID', request['environment']['MAIL_MODULE_UUID'])
+agent.set_env('Z_PUSH_USE_LEGACY_FOLDER_IDS', request['environment']['Z_PUSH_USE_LEGACY_FOLDER_IDS'])
 agent.dump_env()

--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -4,4 +4,5 @@
 # Restic --files-from: https://restic.readthedocs.io/en/stable/040_backup.html#including-files
 #
 volumes/webtop-home
+volumes/z-push_state
 state/webtop5.dump

--- a/imageroot/systemd/user/z-push.service
+++ b/imageroot/systemd/user/z-push.service
@@ -21,6 +21,7 @@ ExecStart=/usr/bin/podman run \
     --cgroups=no-conmon \
     --replace --name=%N \
     --volume=./z-push_config.json:/usr/share/webtop/z-push/config.json:Z \
+    --volume=z-push_state:/var/log/z-push/state \
     ${WEBTOP_Z_PUSH_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/%N.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/%N.ctr-id


### PR DESCRIPTION
The z-push state will be preserved on service reboot and it will be copied during the migration from NS7

Changes:
* podman volume for `z-push` state directory
* added z-push state in the restore/import procedure
* preserved the value of the `Z_PUSH_USE_LEGACY_FOLDER_IDS` env var during the module restore/import

Related PR: NethServer/nethserver-ns8-migration#11