### PR TITLE
Fix module-dump-state

### DIFF
--- a/imageroot/bin/module-dump-state
+++ b/imageroot/bin/module-dump-state
@@ -7,6 +7,4 @@
 
 set -e
 
-if systemctl --user -q is-active postgres; then
-    podman exec postgres pg_dump -U postgres --format=c webtop5 > webtop5.dump
-fi
+podman exec postgres pg_dump -U postgres --format=c webtop5 > webtop5.dump


### PR DESCRIPTION
The script must fail if the DB is not available because it cannot produce a complete backup set. Ignoring this condition might lead to a bogus backup that cannot be restored.