### PR TITLE
 Remove obsolete bash {unset,set}-env

### DIFF
--- a/imageroot/actions/configure-module/05clean_env
+++ b/imageroot/actions/configure-module/05clean_env
@@ -1,17 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env python3
 
 #
-# Copyright (C) 2022 Nethesis S.r.l.
+# Copyright (C) 2023 Nethesis S.r.l.
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
-# Redirect any output to the journal (stderr)
 
-set -e
+import agent
 
-exec 1>&2
-
-cat >&${AGENT_COMFD} <<EOF
-unset-env RESTART_WEBAPP
-unset-env RESTART_WEBDAV
-unset-env RESTART_Z_PUSH
-EOF
+agent.unset_env("RESTART_WEBAPP")
+agent.unset_env("RESTART_WEBDAV")
+agent.unset_env("RESTART_Z_PUSH")

--- a/imageroot/actions/configure-module/70restart_components
+++ b/imageroot/actions/configure-module/70restart_components
@@ -1,29 +1,24 @@
-#!/bin/bash
+#!/usr/bin/env python3
 
 #
-# Copyright (C) 2022 Nethesis S.r.l.
+# Copyright (C) 2023 Nethesis S.r.l.
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
-# Redirect any output to the journal (stderr)
 
-set -e
+import agent
+import os
 
-exec 1>&2
+restart_webapp = os.environ.get('RESTART_WEBAPP','')
+restart_webdav = os.environ.get('RESTART_WEBDAV','')
+restart_z_push = os.environ.get('RESTART_Z_PUSH','')
 
-if [ "$RESTART_WEBAPP" == "1" ]; then
-	systemctl --user restart webapp
-fi
+if restart_webapp == '1':
+    agent.run_helper('systemctl','--user','restart','webapp').check_returncode()
+if restart_webdav == '1':
+    agent.run_helper('systemctl','--user','restart','webdav').check_returncode()
+if restart_z_push == '1':
+    agent.run_helper('systemctl','--user','restart','z-push').check_returncode()
 
-if [ "$RESTART_WEBDAV" == "1" ]; then
-	systemctl --user restart webdav
-fi
-
-if [ "$RESTART_Z_PUSH" == "1" ]; then
-	systemctl --user restart z-push
-fi
-
-cat >&${AGENT_COMFD} <<EOF
-unset-env RESTART_WEBAPP
-unset-env RESTART_WEBDAV
-unset-env RESTART_Z_PUSH
-EOF
+agent.unset_env("RESTART_WEBAPP")
+agent.unset_env("RESTART_WEBDAV")
+agent.unset_env("RESTART_Z_PUSH")

--- a/imageroot/actions/create-module/10env
+++ b/imageroot/actions/create-module/10env
@@ -1,24 +1,20 @@
-#!/bin/bash
+#!/usr/bin/env python3
 
 #
-# Copyright (C) 2022 Nethesis S.r.l.
+# Copyright (C) 2023 Nethesis S.r.l.
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-set -e
+import agent
 
-exec 1>&2 # Send any output to stderr, to not alter the action response protocol
-
-cat >&${AGENT_COMFD} <<EOF
-set-env WEBTOP_TIMEZONE Etc/UTC
-set-env WEBTOP_LOCALE en_US
-set-env WEBTOP_REQUEST_HTTPS_CERTIFICATE False
-set-env WEBDAV_DEBUG False
-set-env WEBDAV_LOG_LEVEL ERROR
-set-env Z_PUSH_LOG_LEVEL ERROR
-set-env Z_PUSH_IMAP_SERVER 10.5.4.1
-set-env Z_PUSH_USE_LEGACY_FOLDER_IDS false
-set-env WEBAPP_JS_DEBUG False
-set-env WEBAPP_MIN_MEMORY 512
-set-env WEBAPP_MAX_MEMORY 1024
-EOF
+agent.set_env('WEBTOP_TIMEZONE', 'Etc/UTC')
+agent.set_env('WEBTOP_LOCALE', 'en_US')
+agent.set_env('WEBTOP_REQUEST_HTTPS_CERTIFICATE', 'False')
+agent.set_env('WEBDAV_DEBUG', 'False')
+agent.set_env('WEBDAV_LOG_LEVEL', 'ERROR')
+agent.set_env('Z_PUSH_LOG_LEVEL', 'ERROR')
+agent.set_env('Z_PUSH_IMAP_SERVER', '10.5.4.1')
+agent.set_env('Z_PUSH_USE_LEGACY_FOLDER_IDS', 'false')
+agent.set_env('WEBAPP_JS_DEBUG', 'False')
+agent.set_env('WEBAPP_MIN_MEMORY', '512')
+agent.set_env('WEBAPP_MAX_MEMORY', '1024')

--- a/imageroot/actions/import-module/20z-push_legacy_ids
+++ b/imageroot/actions/import-module/20z-push_legacy_ids
@@ -1,15 +1,17 @@
-#!/bin/bash
+#!/usr/bin/env python3
 
 #
-# Copyright (C) 2022 Nethesis S.r.l.
+# Copyright (C) 2023 Nethesis S.r.l.
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-set -e -o pipefail
-exec 1>&2 # Redirect any output to the journal (stderr)
+import agent
+import os
+
+path = './legacy_ids_enabled'
+check_file = os.path.exists(path)
 
 # Check if the migrated z-push state use the legacy folder ids format
-if [[ -e ./legacy_ids_enabled ]]; then
-	echo "set-env Z_PUSH_USE_LEGACY_FOLDER_IDS True" >&${AGENT_COMFD}
-	rm ./legacy_ids_enabled
-fi
+if check_file:
+    agent.set_env('Z_PUSH_USE_LEGACY_FOLDER_IDS', 'True')
+    os.remove(path)


### PR DESCRIPTION
following https://trello.com/c/jBkc6Qwt/365-core-p1-agent-set-env-deprecation

Remove the deprecated set-env
Sync the agent Redis */environment key on every action run, no matter for the exit code