### PR TITLE
Update timezone handling in WebTop

### DIFF
--- a/imageroot/actions/create-module/10env
+++ b/imageroot/actions/create-module/10env
@@ -7,7 +7,7 @@
 
 import agent
 
-agent.set_env('WEBTOP_TIMEZONE', 'Etc/UTC')
+agent.set_env('WEBTOP_TIMEZONE', '-')
 agent.set_env('WEBTOP_LOCALE', 'en_US')
 agent.set_env('WEBTOP_REQUEST_HTTPS_CERTIFICATE', 'False')
 agent.set_env('WEBDAV_DEBUG', 'False')

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -36,7 +36,7 @@
     "default_locale_for_webtop_users": "Default locale for WebTop users",
     "timezone":"Default timezone",
     "default_timezone_for_webtop_users": "Default timezone for WebTop users",
-    "choose_timezone": "Choose the timezone for WebTop users",
+    "choose_timezone": "Start to type the timezone name, e.g. Europe/Rome",
     "webapp_debug": "Debug mode for WebTop",
     "min_webapp_memory":"Minimum memory for WebTop",
     "max_webapp_memory": "Maximum memory for WebTop",

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -430,7 +430,7 @@ export default {
         mail_module: "",
         ejabberd_module: "",
         locale: "",
-        timezone: "",
+        accepted_timezone_list: "",
         limit_min: "",
         limit_max: "",
         webapp: {
@@ -599,7 +599,7 @@ export default {
         } else {
           this.ejabberd_module = "-";
         }
-        this.timezone = config.timezone;
+        this.timezone = config.timezone === '-' ? '' : config.timezone;
       });
       this.loading.getConfiguration = false;
       this.focusElement("hostname");
@@ -621,6 +621,14 @@ export default {
 
         if (isValidationOk) {
           this.focusElement("mail_module");
+        }
+        isValidationOk = false;
+      }
+      if (!this.timezone) {
+        this.error.accepted_timezone_list = "common.required";
+
+        if (isValidationOk) {
+          this.focusElement("accepted_timezone_list");
         }
         isValidationOk = false;
       }


### PR DESCRIPTION
This pull request updates the timezone handling in WebTop by making the following changes:

- Update WEBTOP_TIMEZONE environment variable

- Update timezone prompt for WebTop users

- Add validation for timezone field in Settings.vue

These changes ensure that the timezone selection for WebTop users is more user-friendly and that the timezone field is properly validated.

![image](https://github.com/NethServer/ns8-webtop/assets/3164851/44d5dd0a-5dc4-4336-870b-01acad5e6e35)

![image](https://github.com/NethServer/ns8-webtop/assets/3164851/5c0d285b-bd9c-4689-b3dc-9b752dab67d5)

![image](https://github.com/NethServer/ns8-webtop/assets/3164851/f5792daa-f6f1-44ed-b8bc-9a468e3b2717)

![image](https://github.com/NethServer/ns8-webtop/assets/3164851/c982220a-65b9-4710-987e-7cf1ed06cb0a)

https://github.com/NethServer/dev/issues/6826