### PR TITLE
Wait after postgres has finished 

### DIFF
--- a/imageroot/systemd/user/postgres.service
+++ b/imageroot/systemd/user/postgres.service
@@ -23,6 +23,7 @@ ExecStart=/usr/bin/podman run \
     --volume=pgdata:/var/lib/postgresql/data \
     --replace --name=%N \
     ${WEBTOP_POSTGRES_IMAGE}
+ExecStartPost=/usr/bin/bash -c "while ! podman  exec postgres pg_isready ;  do sleep 5 ; done"
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/postgres.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/postgres.ctr-id
 PIDFile=%t/postgres.pid

--- a/imageroot/systemd/user/postgres.service
+++ b/imageroot/systemd/user/postgres.service
@@ -23,7 +23,7 @@ ExecStart=/usr/bin/podman run \
     --volume=pgdata:/var/lib/postgresql/data \
     --replace --name=%N \
     ${WEBTOP_POSTGRES_IMAGE}
-ExecStartPost=/usr/bin/bash -c "while ! podman  exec postgres pg_isready ;  do sleep 5 ; done"
+ExecStartPost=/usr/bin/bash -c "while ! podman  exec postgres psql -U postgres -c '\\l' > /dev/null ;  do sleep 5 ; done"
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/postgres.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/postgres.ctr-id
 PIDFile=%t/postgres.pid


### PR DESCRIPTION
With Slow machine we could have some issue that postgres has not finished to start


webtop use postgresql 9 we cannot  use pg_isready :/

```
[webtop1@R1-pve state]$ podman  exec postgres ls -la /usr/bin/pg_isready 
lrwxrwxrwx. 1 root root 37 Jul 11  2017 /usr/bin/pg_isready -> ../share/postgresql-common/pg_wrapper
[webtop1@R1-pve state]$ podman  exec postgres ls -la /usr/share/postgresql-common/pg_wrapper
-rwxr-xr-x. 1 root root 8935 May 23  2017 /usr/share/postgresql-common/pg_wrapper
[webtop1@R1-pve state]$ podman  exec postgres /usr/share/postgresql-common/pg_wrapper
Error: pg_wrapper called directly but no program given as argument
[webtop1@R1-pve state]$ podman  exec postgres /usr/share/postgresql-common/pg_wrapper pg_isready
Error: pg_wrapper: pg_isready was not found in /usr/lib/postgresql/9.2/bin
[webtop1@R1-pve state]$ podman  exec postgres ls /usr/lib/postgresql/9.2/bin/
clusterdb
createdb
createlang
createuser
dropdb
droplang
dropuser
initdb
oid2name
pg_archivecleanup
pg_basebackup
pgbench
pg_controldata
pg_ctl
pg_dump
pg_dumpall
pg_receivexlog
pg_resetxlog
pg_restore
pg_standby
pg_test_fsync
pg_test_timing
pg_upgrade
postgres
postmaster
psql
reindexdb
vacuumdb
vacuumlo
```
