### PR TITLE
Add mail_domain configuration to webtop.py

### DIFF
--- a/imageroot/pypkg/webtop.py
+++ b/imageroot/pypkg/webtop.py
@@ -15,6 +15,7 @@ def configure_module(mail_module, penv):
         "locale": penv['WEBTOP_LOCALE'],
         "timezone": penv['WEBTOP_TIMEZONE'],
         "mail_module": mail_module,
+        "mail_domain": penv['MAIL_DOMAIN'],
         "ejabberd_module": penv.get('EJABBERD_MODULE',''),
         "webapp": {
             "debug": penv['WEBAPP_JS_DEBUG'] == 'True',


### PR DESCRIPTION
This pull request adds the "mail_domain" configuration option to the webtop.py file in the imageroot/pypkg directory. This configuration option allows for specifying the mail domain for the webtop module.

the configure-module is [restrictive](https://github.com/NethServer/ns8-webtop/blob/2726c8ca4de177d61ef07630ceca3ee1b27dfa89/imageroot/actions/configure-module/20config#L221-L222) and wait after the presence of mail-domain in the json data

https://github.com/NethServer/dev/issues/6879