### PR TITLE
Update userDisplayNameField to use "displayName" instead of "gecos"

### DIFF
--- a/imageroot/actions/configure-module/20config
+++ b/imageroot/actions/configure-module/20config
@@ -26,7 +26,7 @@ def domain_setup(mail_domain, user_domain):
             "userIdField": "uid",
             "userFirstnameField": "givenName",
             "userLastnameField": "sn",
-            "userDisplayNameField": "gecos",
+            "userDisplayNameField": "displayName",
             }
 
     if user_domain["schema"] == "ad":


### PR DESCRIPTION
This pull request updates the `userDisplayNameField` in the `configure-module/20config` file to use the "displayName" field instead of the "gecos" field. 

However 
- when the user has already login, it does not honor the new setting because it has been written to postgres

```
webtop5=# SELECT * FROM core.users;
 domain_id  |   user_id    | type | enabled |               user_uid               |      display_name       |      se
cret      
------------+--------------+------+---------+--------------------------------------+-------------------------+--------
----------
 NethServer | john     | U    | t       | 24e4751b-fc50-4d01-8c65-107a98b7434a | de labrusse             | 3c6sm72
wdpuw22sg
 NethServer | foo       | U    | t       | 3beecb12-63e3-422f-b570-405277fd8cbf | de labrusse             | cqw7q6z
2ydn3i2es
 *          | admin        | U    | t       | 991f72dc-2b96-4340-b88f-53506b160519 | Administrator           | 76gvj7v
bpnuhsf6r
(7 rows)
```

- when you save the configuration after the update of the module, it is not taken except if you change the user domain or the mail server

so in short it is valid only for first installation

https://github.com/NethServer/dev/issues/6923