### PR TITLE
fix: ensure logo image is generated

### DIFF
--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -7,5 +7,16 @@ module.exports = {
         maxSize: 250000
       }
     }
+  },
+  chainWebpack: (config) => {
+    config.module
+      .rule("images")
+      .use("url-loader")
+      .loader("url-loader")
+      .tap((options) => {
+        // Do not base64 encode images URLs. Needed to always generate module logo image
+        options.limit = -1;
+        return options;
+      });
   }
 };

--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -4,8 +4,8 @@ module.exports = {
     optimization: {
       splitChunks: {
         minSize: 10000,
-        maxSize: 250000,
-      },
-    },
-  },
+        maxSize: 250000
+      }
+    }
+  }
 };


### PR DESCRIPTION
By default vue-cli-service does not generate images smaller than 4KB but replaces them with inline base64. This change ensures that image files (like module logo) are always generated, regardless of their size.

See:
- https://github.com/NethServer/dev/issues/6954