### PR TITLE
Add Pecbridge service to Webtop

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -9,6 +9,6 @@ permissions:
 jobs:
   publish-images:
     if: github.run_number > 1
-    uses: NethServer/ns8-github-actions/.github/workflows/publish-branch.yml@main
+    uses: NethServer/ns8-github-actions/.github/workflows/publish-branch.yml@v1
     secrets:
-        netrcb64: ${{ secrets.NETRCB64 }}
+      netrcb64: ${{ secrets.NETRCB64 }}

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -14,10 +14,10 @@ on:
 jobs:
   module:
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == '' }}
-    uses: NethServer/ns8-github-actions/.github/workflows/module-info.yml@main
+    uses: NethServer/ns8-github-actions/.github/workflows/module-info.yml@v1
   run_tests_on_do:
     needs: module
-    uses: NethServer/ns8-github-actions/.github/workflows/test-on-digitalocean-infra.yml@main
+    uses: NethServer/ns8-github-actions/.github/workflows/test-on-digitalocean-infra.yml@v1
     with:
       args: "ghcr.io/${{needs.module.outputs.owner}}/${{needs.module.outputs.name}}:${{needs.module.outputs.tag}}"
       repo_ref: ${{needs.module.outputs.sha}}

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Pecbridge download binaries
+pecbridge-*.tar.gz

--- a/CHECKSUM
+++ b/CHECKSUM
@@ -1,0 +1,1 @@
+ccce4cbca992a32291babe79458ef5a413f380d2c903f6bce363d0f01d42a136  pecbridge-5.4.0.tar.gz

--- a/build-images.sh
+++ b/build-images.sh
@@ -13,8 +13,8 @@ repobase="${REPOBASE:-ghcr.io/nethserver}"
 webtop_version=$(cat ${PWD}/webtop5-build/VERSION)
 
 # Download of external deps and CHECKSUM verification:
-if [[ ! -f pecbridge-5.4.0.tar.gz ]]; then
-    curl -n --fail -O https://www.sonicle.com/nethesis/commercial/pecbridge/pecbridge-5.4.0.tar.gz
+if ! compgen -G "pecbridge-*.tar.gz"; then
+    curl --netrc --fail -O "https://www.sonicle.com/nethesis/commercial/pecbridge/pecbridge-5.4.0.tar.gz"
 fi
 sha256sum -c CHECKSUM
 

--- a/imageroot/actions/create-module/12api_token
+++ b/imageroot/actions/create-module/12api_token
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import agent
+import os
+import string
+import secrets
+
+try:
+    webapp_env = agent.read_envfile("webapp.env")
+except FileNotFoundError:
+    # Generate a new API token, for webtop.properties expansion
+    alphabet = string.ascii_letters + string.digits
+    api_token = ''.join([secrets.choice(alphabet) for i in range(32)])
+    webapp_env = {
+        "WEBAPP_API_TOKEN": api_token,
+    }
+    agent.write_envfile("webapp.env", webapp_env)

--- a/imageroot/scripts/expandconfig-webapp
+++ b/imageroot/scripts/expandconfig-webapp
@@ -7,9 +7,12 @@
 
 set -e
 
+source webapp.env
+
 cat <<EOF > webtop.properties
 webtop.log.target=console
 webtop.session.forcesecurecookie=true
 webtop.js.debug=$WEBAPP_JS_DEBUG
 webtop.home=/var/lib/nethserver/webtop
+webtop.provisioning.api.token=$WEBAPP_API_TOKEN
 EOF

--- a/imageroot/scripts/expandconfig-webapp
+++ b/imageroot/scripts/expandconfig-webapp
@@ -15,6 +15,7 @@ webtop.session.forcesecurecookie=true
 webtop.js.debug=$WEBAPP_JS_DEBUG
 webtop.home=/var/lib/nethserver/webtop
 webtop.provisioning.api.token=$WEBAPP_API_TOKEN
+webtop.mailbridge.mode=api
 webtop.mailbridge.smtp.host=127.0.0.1
 webtop.mailbridge.smtp.port=10125
 webtop.mailbridge.smtp.auth=true

--- a/imageroot/scripts/expandconfig-webapp
+++ b/imageroot/scripts/expandconfig-webapp
@@ -18,4 +18,5 @@ webtop.provisioning.api.token=$WEBAPP_API_TOKEN
 webtop.mailbridge.smtp.host=127.0.0.1
 webtop.mailbridge.smtp.port=10125
 webtop.mailbridge.smtp.auth=true
+mail.smtp.timeout=170000
 EOF

--- a/imageroot/scripts/expandconfig-webapp
+++ b/imageroot/scripts/expandconfig-webapp
@@ -15,4 +15,7 @@ webtop.session.forcesecurecookie=true
 webtop.js.debug=$WEBAPP_JS_DEBUG
 webtop.home=/var/lib/nethserver/webtop
 webtop.provisioning.api.token=$WEBAPP_API_TOKEN
+webtop.mailbridge.smtp.host=127.0.0.1
+webtop.mailbridge.smtp.port=10125
+webtop.mailbridge.smtp.auth=true
 EOF

--- a/imageroot/systemd/user/pecbridge.service
+++ b/imageroot/systemd/user/pecbridge.service
@@ -18,6 +18,7 @@ ExecStart=/usr/bin/podman run \
     --cgroups=no-conmon \
     --replace --name=%N \
     --env-file webapp.env \
+    --env PECBRIDGE_ADMIN_MAIL \
     --volume=./webtop.properties:/etc/webtop/webtop.properties:z \
     --entrypoint=/usr/share/pecbridge/bin/run.sh \
     ${WEBTOP_WEBAPP_IMAGE}

--- a/imageroot/systemd/user/pecbridge.service
+++ b/imageroot/systemd/user/pecbridge.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=WebTop Pecbridge
+Requires=webapp.service
+After=webapp.service
+
+[Service]
+Type=forking
+Environment=PODMAN_SYSTEMD_UNIT=%n
+EnvironmentFile=%S/state/environment
+WorkingDirectory=%S/state
+Restart=always
+ExecStartPre=/bin/rm -f %t/pecbridge.pid %t/pecbridge.ctr-id
+ExecStart=/usr/bin/podman run \
+    --pod=webtop \
+    --detach \
+    --conmon-pidfile=%t/pecbridge.pid \
+    --cidfile=%t/pecbridge.ctr-id \
+    --cgroups=no-conmon \
+    --replace --name=%N \
+    --env-file webapp.env \
+    --volume=./webtop.properties:/etc/webtop/webtop.properties:z \
+    --entrypoint=/usr/share/pecbridge/bin/run.sh \
+    ${WEBTOP_WEBAPP_IMAGE}
+SuccessExitStatus=143
+ExecStop=/usr/bin/podman stop --ignore --cidfile %t/pecbridge.ctr-id -t 10
+ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/pecbridge.ctr-id
+PIDFile=%t/pecbridge.pid

--- a/imageroot/systemd/user/webapp.service
+++ b/imageroot/systemd/user/webapp.service
@@ -22,7 +22,7 @@ ExecStart=/usr/bin/podman run \
 			 -Dmail.mime.address.strict=false -Dwebtop.etc.dir=/etc/webtop \
 			 -Duser.timezone=${WEBTOP_TIMEZONE}" \
     --volume=webtop-home:/var/lib/nethserver/webtop \
-    --volume=./webtop.properties:/etc/webtop/webtop.properties:Z \
+    --volume=./webtop.properties:/etc/webtop/webtop.properties:z \
     --pod=webtop \
     --detach \
     --conmon-pidfile=%t/webapp.pid \
@@ -30,7 +30,6 @@ ExecStart=/usr/bin/podman run \
     --cgroups=no-conmon \
     --replace --name=%N \
     ${WEBTOP_WEBAPP_IMAGE}
-ExecStartPost=/usr/bin/podman exec --detach webapp /usr/share/pecbridge/bin/run.sh
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/webapp.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/webapp.ctr-id
 PIDFile=%t/webapp.pid

--- a/imageroot/systemd/user/webapp.service
+++ b/imageroot/systemd/user/webapp.service
@@ -30,6 +30,7 @@ ExecStart=/usr/bin/podman run \
     --cgroups=no-conmon \
     --replace --name=%N \
     ${WEBTOP_WEBAPP_IMAGE}
+ExecStartPost=/usr/bin/podman exec --detach webapp /usr/share/pecbridge/bin/run.sh
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/webapp.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/webapp.ctr-id
 PIDFile=%t/webapp.pid

--- a/imageroot/systemd/user/webtop.service
+++ b/imageroot/systemd/user/webtop.service
@@ -4,8 +4,8 @@
 #
 [Unit]
 Description=WebTop pod service
-Wants=webapp.service postgres.service apache.service webdav.service z-push.service
-Before=webapp.service postgres.service apache.service webdav.service z-push.service
+Wants=webapp.service postgres.service apache.service webdav.service z-push.service pecbridge.service
+Before=webapp.service postgres.service apache.service webdav.service z-push.service pecbridge.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n

--- a/imageroot/systemd/user/webtop.service
+++ b/imageroot/systemd/user/webtop.service
@@ -20,6 +20,7 @@ ExecStartPre=/usr/bin/podman pod create \
     --publish=${TCP_PORT}:8081 \
     --network=slirp4netns:allow_host_loopback=true \
     --add-host=accountprovider:10.0.2.2 \
+    --add-host=mailnode:${Z_PUSH_IMAP_SERVER} \
     --replace
 ExecStart=/usr/bin/podman pod start --pod-id-file %t/webtop.pod-id
 ExecStop=/usr/bin/podman pod stop --ignore --pod-id-file %t/webtop.pod-id -t 10

--- a/imageroot/update-module.d/12api_token
+++ b/imageroot/update-module.d/12api_token
@@ -1,0 +1,1 @@
+../actions/create-module/12api_token

--- a/webapp/usr/share/pecbridge/bin/run.sh
+++ b/webapp/usr/share/pecbridge/bin/run.sh
@@ -12,9 +12,6 @@ cd "$PBHOME"
 CLASSPATH=lib/*:classes
 export PATH CLASSPATH
 
-# Parse the webtop.properties file to extract the API token value:
-WEBAPP_API_TOKEN=$(awk -F = '/^webtop\.provisioning\.api\.token/ { print $2 }' /etc/webtop/webtop.properties)
-
 # Expand the Pecbridge configuration file template:
 sed "s/WEBAPP_API_TOKEN/${WEBAPP_API_TOKEN:?}/" etc/config.xml.template > etc/config.xml
 

--- a/webapp/usr/share/pecbridge/bin/run.sh
+++ b/webapp/usr/share/pecbridge/bin/run.sh
@@ -5,15 +5,19 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+set -e
+
 PBHOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 
 cd "$PBHOME"
 
-CLASSPATH=lib/*:classes
+CLASSPATH="lib/*:classes"
 export PATH CLASSPATH
 
 # Expand the Pecbridge configuration file template:
-sed "s/WEBAPP_API_TOKEN/${WEBAPP_API_TOKEN:?}/" etc/config.xml.template > etc/config.xml
+sed -e "s/WEBAPP_API_TOKEN/${WEBAPP_API_TOKEN:?}/" \
+    ${PECBRIDGE_ADMIN_MAIL:+-e "1 s/sonicle-pec-bridge /sonicle-pec-bridge adminMail=\"${PECBRIDGE_ADMIN_MAIL}\" /"} \
+    etc/config.xml.template > etc/config.xml
 
 # Start the Pecbridge process
 exec java com.sonicle.pecbridge.Main etc/config.xml

--- a/webapp/usr/share/pecbridge/bin/run.sh
+++ b/webapp/usr/share/pecbridge/bin/run.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+PBHOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
+
+cd "$PBHOME"
+
+CLASSPATH=lib/*:classes
+export PATH CLASSPATH
+
+# Parse the webtop.properties file to extract the API token value:
+WEBAPP_API_TOKEN=$(awk -F = '/^webtop\.provisioning\.api\.token/ { print $2 }' /etc/webtop/webtop.properties)
+
+# Expand the Pecbridge configuration file template:
+sed "s/WEBAPP_API_TOKEN/${WEBAPP_API_TOKEN:?}/" etc/config.xml.template > etc/config.xml
+
+# Start the Pecbridge process
+exec java com.sonicle.pecbridge.Main etc/config.xml

--- a/webapp/usr/share/pecbridge/classes/logback.xml
+++ b/webapp/usr/share/pecbridge/classes/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+        <target>System.out</target>
+    </appender>
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/webapp/usr/share/pecbridge/etc/config.xml.template
+++ b/webapp/usr/share/pecbridge/etc/config.xml.template
@@ -1,5 +1,6 @@
 <sonicle-pec-bridge port="10125">
-    <default host="localhost" port="25" debug="false" />
+    <!-- "mailnode" is resolved to the Mail module VPN IP address -->
+    <default host="mailnode" port="10587" debug="false" auth="false" />
     <webtop-api basePath="http://localhost:8080/webtop/api/com.sonicle.webtop.core/v1" bearer="WEBAPP_API_TOKEN" iddomain="NethServer" />
     <fetch delay="60" />
 </sonicle-pec-bridge>

--- a/webapp/usr/share/pecbridge/etc/config.xml.template
+++ b/webapp/usr/share/pecbridge/etc/config.xml.template
@@ -1,6 +1,6 @@
 <sonicle-pec-bridge port="10125">
     <!-- "mailnode" is resolved to the Mail module VPN IP address -->
-    <default host="mailnode" port="10587" debug="false" auth="false" />
+    <default host="mailnode" port="10587" debug="false" auth="true" />
     <webtop-api basePath="http://localhost:8080/webtop/api/com.sonicle.webtop.core/v1" bearer="WEBAPP_API_TOKEN" iddomain="NethServer" />
     <fetch delay="60" />
 </sonicle-pec-bridge>

--- a/webapp/usr/share/pecbridge/etc/config.xml.template
+++ b/webapp/usr/share/pecbridge/etc/config.xml.template
@@ -1,0 +1,5 @@
+<sonicle-pec-bridge port="10125">
+    <default host="localhost" port="25" debug="false" />
+    <webtop-api basePath="http://localhost:8080/webtop/api/com.sonicle.webtop.core/v1" bearer="WEBAPP_API_TOKEN" iddomain="NethServer" />
+    <fetch delay="60" />
+</sonicle-pec-bridge>


### PR DESCRIPTION
- Download Pecbridge binary from Sonicle server with HTTP authentication
- Check the binary matches CHECKSUM file
- Generate WEBAPP_API_TOKEN on app installation/upgrade (the token is stored in a separate file to keep it secret)
- Run Pecbridge process ~~in existing Webapp~~ a separate container. Host `mailnode` is added to Pecbridge config.xml with Z_PUSH_IMAP_SERVER IP address, to reach the Mail app server.
- Use PECBRIDGE_ADMIN_MAIL environment variable to expand PB `config.xml`. If a value is set, it must be a valid email address that will receive a copy of PB notifications.

Refs https://github.com/NethServer/dev/issues/6984

With the above changes, the Pecbridge must still be configured manually from Webtop admin panel until Sonicle releases a new upstream version with automatic configuration after the Pecbridge license key is inserted.