### PR TITLE
Remove bash expansion of the bind password

### DIFF
--- a/imageroot/actions/configure-module/20config
+++ b/imageroot/actions/configure-module/20config
@@ -18,7 +18,7 @@ def domain_setup(mail_domain, user_domain):
 
     user_domain_password = subprocess.check_output(
         [
-            'podman', 'run', '--rm', '-i', os.environ["WEBTOP_WEBAPP_IMAGE"],
+            'podman', 'run', '--replace', '--name', 'webtop-pass-encode', '--rm', '-i', os.environ["WEBTOP_WEBAPP_IMAGE"],
             "java", "-classpath", "/usr/share/webtop/", "WebtopPassEncode"
         ],
         input=user_domain["bind_password"],

--- a/imageroot/actions/configure-module/20config
+++ b/imageroot/actions/configure-module/20config
@@ -19,7 +19,7 @@ def domain_setup(mail_domain, user_domain):
     user_domain_password = subprocess.check_output(
         [
             'podman', 'run', '--rm', '-i', os.environ["WEBTOP_WEBAPP_IMAGE"],
-            'bash', '-c', "java -classpath /usr/share/webtop/ WebtopPassEncode"
+            "java", "-classpath", "/usr/share/webtop/", "WebtopPassEncode"
         ],
         input=user_domain["bind_password"],
         text=True

--- a/imageroot/actions/configure-module/20config
+++ b/imageroot/actions/configure-module/20config
@@ -16,7 +16,14 @@ def domain_setup(mail_domain, user_domain):
     user_domain_uri = "ldapneth://accountprovider" + ":" + user_domain["port"]
     user_domain_admin = user_domain["bind_dn"]
 
-    user_domain_password = subprocess.check_output(['podman', 'run', '--rm', os.environ["WEBTOP_WEBAPP_IMAGE"], 'bash', '-c', "echo -n " + user_domain["bind_password"] + " | java -classpath /usr/share/webtop/ WebtopPassEncode"], text=True).splitlines().pop()
+    user_domain_password = subprocess.check_output(
+        [
+            'podman', 'run', '--rm', '-i', os.environ["WEBTOP_WEBAPP_IMAGE"],
+            'bash', '-c', "java -classpath /usr/share/webtop/ WebtopPassEncode"
+        ],
+        input=user_domain["bind_password"],
+        text=True
+    ).strip()
 
     user_domain_parameters = {
             "loginDn": user_domain["base_dn"],


### PR DESCRIPTION
This pull request removes the use of bash expansion for the bind password in the `configure-module/20config` file. Instead, it uses a subprocess to securely pass the password to the `java` command for encoding. This change improves the security of the password handling in the code and also remove the issue with special quote character in the password password


https://github.com/NethServer/dev/issues/6992