### PR TITLE
Add PEC bridge admin mail field to configuration

### DIFF
--- a/imageroot/actions/configure-module/20config
+++ b/imageroot/actions/configure-module/20config
@@ -307,3 +307,7 @@ if "zpush" in data:
     if "loglevel" in data["zpush"] and data["zpush"]["loglevel"] != os.getenv("Z_PUSH_LOG_LEVEL"):
             agent.set_env("Z_PUSH_LOG_LEVEL", data["zpush"]["loglevel"])
             agent.set_env("RESTART_Z_PUSH", "1")
+
+if "pecbridge_admin_mail" in data and data["pecbridge_admin_mail"] != os.getenv("PECBRIDGE_ADMIN_MAIL"):
+    agent.set_env("PECBRIDGE_ADMIN_MAIL", data["pecbridge_admin_mail"])
+    agent.set_env("RESTART_PEC_BRIDGE", "1")

--- a/imageroot/actions/configure-module/70restart_components
+++ b/imageroot/actions/configure-module/70restart_components
@@ -11,6 +11,7 @@ import os
 restart_webapp = os.environ.get('RESTART_WEBAPP','')
 restart_webdav = os.environ.get('RESTART_WEBDAV','')
 restart_z_push = os.environ.get('RESTART_Z_PUSH','')
+restart_pec_bridge = os.environ.get('RESTART_PEC_BRIDGE','')
 
 if restart_webapp == '1':
     agent.run_helper('systemctl','--user','restart','webapp').check_returncode()
@@ -19,6 +20,10 @@ if restart_webdav == '1':
 if restart_z_push == '1':
     agent.run_helper('systemctl','--user','restart','z-push').check_returncode()
 
+if restart_pec_bridge == '1':
+    agent.run_helper('systemctl','--user','restart','pecbridge').check_returncode()
+
 agent.unset_env("RESTART_WEBAPP")
 agent.unset_env("RESTART_WEBDAV")
 agent.unset_env("RESTART_Z_PUSH")
+agent.unset_env("RESTART_PEC_BRIDGE")

--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -144,6 +144,20 @@
                     ]
                 }
             }
+        },
+        "pecbridge_admin_mail": {
+            "anyOf": [
+                {
+                    "type": "string",
+                    "title": "PEC bridge admin mail",
+                    "description": "Email address of the PEC bridge administrator",
+                    "format": "email"
+                },
+                {
+                  "const": "",
+                  "description": "Accept an empty string to clear the setting"
+                }
+            ]
         }
     }
 }

--- a/imageroot/actions/get-configuration/20readconfig
+++ b/imageroot/actions/get-configuration/20readconfig
@@ -30,6 +30,7 @@ config={
         "zpush": {
             "loglevel": os.environ["Z_PUSH_LOG_LEVEL"],
             },
+        "pecbridge_admin_mail": os.getenv("PECBRIDGE_ADMIN_MAIL", ""),
         }
 
 json.dump(config, fp=sys.stdout)

--- a/imageroot/actions/get-configuration/validate-output.json
+++ b/imageroot/actions/get-configuration/validate-output.json
@@ -142,6 +142,22 @@
                     ]
                 }
             }
+        },
+        "pecbridge_admin_mail": {
+            "anyOf": [
+                {
+                  "type": "string",
+                  "title": "PEC bridge admin mail",
+                  "description": "Email address of the PEC bridge administrator",
+                  "format": "email"
+                },
+                {
+                    "type": "string",
+                    "title": "PEC bridge admin mail",
+                    "description": "Email address of the PEC bridge administrator",
+                    "pattern": "^$"
+                }
+            ]
         }
     }
 }

--- a/imageroot/actions/get-configuration/validate-output.json
+++ b/imageroot/actions/get-configuration/validate-output.json
@@ -146,16 +146,14 @@
         "pecbridge_admin_mail": {
             "anyOf": [
                 {
-                  "type": "string",
-                  "title": "PEC bridge admin mail",
-                  "description": "Email address of the PEC bridge administrator",
-                  "format": "email"
-                },
-                {
                     "type": "string",
                     "title": "PEC bridge admin mail",
                     "description": "Email address of the PEC bridge administrator",
-                    "pattern": "^$"
+                    "format": "email"
+                },
+                {
+                  "const": "",
+                  "description": "Accept an empty string to clear the setting"
                 }
             ]
         }

--- a/imageroot/pypkg/webtop.py
+++ b/imageroot/pypkg/webtop.py
@@ -28,5 +28,6 @@ def configure_module(mail_module, penv):
         },
         "zpush": {
             "loglevel": penv['Z_PUSH_LOG_LEVEL'],
-        }
+        },
+        "pecbridge_admin_mail": penv.get('PECBRIDGE_ADMIN_MAIL',''),
     })

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -69,11 +69,10 @@
         "mail_module_misconfigured": "No mail domain available",
         "hostname_pattern": "Must be a valid fully qualified domain name",
         "hostname_format": "Must be a valid fully qualified domain name",
-        "pecbridge_admin_mail": "PECBridge admin mail",
-        "pecbridge_admin_mail_placeholder": "Enter the PECBridge admin mail",
-        "pecbridge_admin_mail_tooltip": "The PECBridge admin mail is used to send notifications to the PECBridge administrator",
-        "pecbridge_admin_mail_format": "Must be a valid email address",
-        "pecbridge_admin_mail_pattern": "Must be a valid email address"
+        "pecbridge_admin_mail": "PEC Bridge notify address (optional)",
+        "pecbridge_admin_mail_placeholder": "E.g. mail-admin@example.org",
+        "pecbridge_admin_mail_tooltip": "If an email address is set, PEC Bridge will send a copy of notifications to it.",
+        "pecbridge_admin_mail_format": "Must be a valid email address"
     },
     "about": {
         "title": "About"

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -68,7 +68,12 @@
         "no_available_mail_domain_check_users": "Make sure the mail domain you intend to use has \"Add user addresses from user domain\" checkbox enabled",
         "mail_module_misconfigured": "No mail domain available",
         "hostname_pattern": "Must be a valid fully qualified domain name",
-        "hostname_format": "Must be a valid fully qualified domain name"
+        "hostname_format": "Must be a valid fully qualified domain name",
+        "pecbridge_admin_mail": "PECBridge admin mail",
+        "pecbridge_admin_mail_placeholder": "Enter the PECBridge admin mail",
+        "pecbridge_admin_mail_tooltip": "The PECBridge admin mail is used to send notifications to the PECBridge administrator",
+        "pecbridge_admin_mail_format": "Must be a valid email address",
+        "pecbridge_admin_mail_pattern": "Must be a valid email address"
     },
     "about": {
         "title": "About"

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -344,6 +344,23 @@
                       $t("settings.LOG_WARNING")
                     }}</cv-dropdown-item>
                   </cv-dropdown>
+                  <NsTextInput
+                    :label="$t('settings.pecbridge_admin_mail')"
+                    :placeholder="$t('settings.pecbridge_admin_mail_placeholder')"
+                    v-model.trim="pecbridge_admin_mail"
+                    class="mg-bottom"
+                    :invalid-message="$t(error.pecbridge_admin_mail)"
+                    :disabled="
+                      loading.getConfiguration ||
+                      loading.configureModule ||
+                      loading.getDefaults
+                    "
+                    ref="pecbridge_admin_mail"
+                  >
+                    <template #tooltip>{{
+                      $t("settings.pecbridge_admin_mail_tooltip")
+                    }}</template>
+                  </NsTextInput>
                 </template>
               </cv-accordion-item>
             </cv-accordion>
@@ -427,6 +444,7 @@ export default {
       zpush: {
         loglevel: "ERROR",
       },
+      pecbridge_admin_mail: "",
       loading: {
         getConfiguration: false,
         configureModule: false,
@@ -455,6 +473,7 @@ export default {
         zpush: {
           loglevel: "",
         },
+        pecbridge_admin_mail: "",
       },
     };
   },
@@ -593,6 +612,7 @@ export default {
       this.webdav = config.webdav;
       this.zpush = config.zpush;
       this.locale = config.locale;
+      this.pecbridge_admin_mail = config.pecbridge_admin_mail;
       // force to reload value after dom update
       this.$nextTick(() => {
         const mail_module_tmp = config.mail_module;
@@ -730,6 +750,7 @@ export default {
             zpush: {
               loglevel: this.zpush.loglevel,
             },
+            pecbridge_admin_mail: this.pecbridge_admin_mail,
           },
           extra: {
             title: this.$t("settings.instance_configuration", {


### PR DESCRIPTION
This pull request adds a new field, `PEC Bridge notify address`, to the configuration module. The field allows the user to enter the email address of the PEC bridge administrator. The changes include adding the field to the validate-input.json and validate-output.json files, as well as updating the translation.json and Settings.vue files to include the new field.

Refs NethServer/dev#6984


![Capture d’écran du 2024-09-20 14-51-37](https://github.com/user-attachments/assets/9f4859e2-a062-4ef1-8341-f8ce4cdf5c60)
![Capture d’écran du 2024-09-20 14-51-44](https://github.com/user-attachments/assets/5b5898e6-b79d-4998-9372-53a25864f583)


