### PR TITLE
systemd: fix expandconfig-webapp invocation

### DIFF
--- a/imageroot/systemd/user/webapp.service
+++ b/imageroot/systemd/user/webapp.service
@@ -14,7 +14,7 @@ EnvironmentFile=%S/state/environment
 WorkingDirectory=%S/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/webapp.pid %t/webapp.ctr-id
-ExecStartPre=%S/scripts/expandconfig-webapp
+ExecStartPre=/usr/local/bin/runagent %S/scripts/expandconfig-webapp
 ExecStart=/usr/bin/podman run \
     --env=CATALINA_OPTS="-server -Xms${WEBAPP_MIN_MEMORY}m -Xmx${WEBAPP_MAX_MEMORY}m \
                          -Djava.security.egd=file:/dev/./urandom -Dfile.encoding=UTF8 \


### PR DESCRIPTION
Execute `expandconfig-webapp` using `runagent`, otherwise the `AGENT_INSTALL_DIR` variable will not be set.

NethServer/dev#6984
