### PR TITLE
Enable new Nethesis theme

### DIFF
--- a/imageroot/actions/import-module/60tryme_theme
+++ b/imageroot/actions/import-module/60tryme_theme
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+
+mkdir -p ${AGENT_STATE_DIR}/webtop.properties.d
+cat <<EOF > ${AGENT_STATE_DIR}/webtop.properties.d/31theme
+webtop.ui.presets.extra=nethesis:Nethesis|nethesis|nethesis
+webtop.ui.preset.tryme=nethesis
+EOF

--- a/imageroot/templates/webtop.properties.d/10builtin
+++ b/imageroot/templates/webtop.properties.d/10builtin
@@ -3,3 +3,5 @@ webtop.session.forcesecurecookie=true
 webtop.js.debug=${WEBAPP_JS_DEBUG}
 webtop.home=/var/lib/nethserver/webtop
 webtop.provisioning.api.token=${WEBAPP_API_TOKEN}
+webtop.admin.mode.singledomain=true
+webtop.admin.logviewer.enabled=false

--- a/imageroot/templates/webtop.properties.d/30ui
+++ b/imageroot/templates/webtop.properties.d/30ui
@@ -1,1 +1,3 @@
+webtop.ui.layouts=default
+webtop.ui.layout.forced=default
 webtop.login.template.vars=login_people:show

--- a/imageroot/templates/webtop.properties.d/31theme
+++ b/imageroot/templates/webtop.properties.d/31theme
@@ -1,0 +1,2 @@
+webtop.ui.presets=nethesis:Nethesis|nethesis|nethesis
+webtop.ui.preset.forced=nethesis

--- a/imageroot/update-module.d/13ui_tryme
+++ b/imageroot/update-module.d/13ui_tryme
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import os
+import agent
+import semver
+
+
+# Extract prevous version from the image tag of PREV_IMAGE_URL environment variable
+prev_image = os.environ.get('PREV_IMAGE_URL')
+
+if prev_image is not None:
+    # Extract the image tag from the URL
+    prev_tag= prev_image.split(':')[-1]
+    try:
+        prev_version = semver.VersionInfo.parse(prev_tag)
+        # Check if the previous version is less than or equal to 1.0.21
+        if prev_version <= semver.VersionInfo.parse('1.0.21'):
+            # Create the directory webtop.properties.d in the module state directory
+            os.makedirs(f'{os.environ["AGENT_STATE_DIR"]}/webtop.properties.d', exist_ok=True)
+            # Write the 31theme into the webtop.properties.d directory to enable the tryme on Netesis theme
+            with open(f'{os.environ["AGENT_STATE_DIR"]}/webtop.properties.d/31theme', 'w') as f:
+                f.write('webtop.ui.presets.extra=nethesis:Nethesis|nethesis|nethesis\n')
+                f.write('webtop.ui.preset.tryme=nethesis\n')
+    except ValueError:
+        pass

--- a/webtop5-build/prep-sources
+++ b/webtop5-build/prep-sources
@@ -65,9 +65,11 @@ if [ "$base_branch" == "release" -o  "$base_branch" == "develop" ]; then
     USE_LFS=0 \
     DEFAULT_CLONE_BASEURL=https://bitbucket.org/sonicle \
     DEFAULT_MVNTOOLS_CLONE_BASEURL=https://bitbucket.org/sonicle \
-    DEFAULT_BASE_BRANCH=$base_branch
+    DEFAULT_BASE_BRANCH=$base_branch \
+    COMPONENTS_COM=webtop-nethesis-laf \
+    MOD_FLAGS.webtop-nethesis-laf=git-develop,git-release
 else
-  make setup USE_LFS=0
+  make setup USE_LFS=0 COMPONENTS_COM=webtop-nethesis-laf MOD_FLAGS.webtop-nethesis-laf=git-develop,git-release
   make checkout-tag TAG=$tag_name
 fi
 
@@ -86,7 +88,10 @@ pushd webtop-gate
 echo
 echo "Building..."
 echo
-make build
+make build \
+    COMPONENTS_COM=webtop-nethesis-laf \
+    MOD_FLAGS.webtop-nethesis-laf=git-develop,git-release \
+    MOD_BUILDS_ARGS.webtop-webapp.default="-P bundle-nethesis-theme"
 
 echo
 echo "Extracting sql scripts..."


### PR DESCRIPTION
build:
  - Add new `webtop-nethesis-laf` component

webtop.properties:
  - Disable multiple domain mode in WebTop's admin interface
  - Disable LogViewer panel in admin management
  - Select default layout and enable new UI theme.
See: https://www.sonicle.com/docs/webtop5/core.html#core-system-properties

New behaviors:
* On fresh installation, use the new theme as the default
* On migration/update, let the user try the theme before making a choose

https://github.com/NethServer/dev/issues/7033
