### PR TITLE
Fix missing settings on migration

### DIFF
--- a/imageroot/actions/configure-module/21update_settings
+++ b/imageroot/actions/configure-module/21update_settings
@@ -1,0 +1,1 @@
+../../update-module.d/11update_settings

--- a/imageroot/update-module.d/11update_settings
+++ b/imageroot/update-module.d/11update_settings
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+# WARNING: This step is executed also in the `configure-module` action on step
+# `21upate_settings, be aware of that.
+
 import sys
 import agent
 import subprocess


### PR DESCRIPTION
Some defaults of the WebTop application are stored in the PostgreSQL database. To create new defaults or modify existing ones, the settings are changed in the initialization script during a fresh installation or via the `update-module.d` step during an update.

However, during migration, the step in `update-module.d` is not executed, and the database initialization script is not invoked because the database is restored from a dump of the old one. As a result, the new default settings are not adjusted.

Since the `configure-module` action is launched as the final step of migration, as a workaround, the setting adjustment step from `update-module.d` is also included in `configure-module`.

https://github.com/NethServer/dev/issues/7033
