### PR TITLE
Disable What's New window

### DIFF
--- a/imageroot/update-module.d/11update_settings
+++ b/imageroot/update-module.d/11update_settings
@@ -23,5 +23,7 @@ with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-qU', 'postg
     print("INSERT INTO \"core\".\"settings\" (service_id, key, value) VALUES ('com.sonicle.webtop.core', 'default.startup.service', 'com.sonicle.webtop.mail');\n", file=psql.stdin)
     print("DELETE FROM \"core\".\"settings\" WHERE service_id = 'com.sonicle.webtop.calendar' AND key = 'default.scheduler.timeresolution';\n", file=psql.stdin)
     print("INSERT INTO \"core\".\"settings\" (service_id, key, value) VALUES ('com.sonicle.webtop.calendar', 'default.scheduler.timeresolution', '15');\n", file=psql.stdin)
+    print("DELETE FROM \"core\".\"settings\" WHERE service_id = 'com.sonicle.webtop.core' AND key = 'whatsnew.enabled';\n", file=psql.stdin)
+    print("INSERT INTO \"core\".\"settings\" (service_id, key, value) VALUES ('com.sonicle.webtop.core', 'whatsnew.enabled', 'false');\n", file=psql.stdin)
 
 agent.assert_exp(psql.returncode == 0) # check the command is succesfull

--- a/postgres/data/init-data-nethserver.sql
+++ b/postgres/data/init-data-nethserver.sql
@@ -181,3 +181,8 @@ INSERT INTO "core"."settings" ("service_id","key","value") VALUES ('com.sonicle.
 -- Set default calendar scheduler time resolution to 15 minutes
 -- ------------------------------------------------------------
 INSERT INTO "core"."settings" ("service_id","key","value") VALUES ('com.sonicle.webtop.calendar','default.scheduler.timeresolution','15');
+
+-- ----------------
+-- Disable WhatsNew
+-- ----------------
+INSERT INTO core.settings(service_id,key,value) VALUES ('com.sonicle.webtop.core','whatsnew.enabled','false');


### PR DESCRIPTION
Often, the "What's New" display shows irrelevant information, outdated content, or features not enabled on the NethServer flavor of WebTop. This update disables the "What's New" window to avoid user confusion and trouble.

https://github.com/NethServer/dev/issues/7033
