### PR TITLE
Add webtop.uuid to properties

### DIFF
--- a/imageroot/templates/webtop.properties.d/10builtin
+++ b/imageroot/templates/webtop.properties.d/10builtin
@@ -1,3 +1,4 @@
+webtop.uuid=${MODULE_UUID}
 webtop.log.target=console
 webtop.session.forcesecurecookie=true
 webtop.js.debug=${WEBAPP_JS_DEBUG}


### PR DESCRIPTION
The MODULE_UUID value is assigned to Webtop's `webtop.uuid` configuration property. Their UUID can be the same as effectively a ns8 app instance of Webtop tracks a Webtop instance itself.

Refs https://github.com/NethServer/dev/issues/7071