### PR TITLE
Autodiscovery LDAP with service restart

### DIFF
--- a/imageroot/actions/configure-module/20config
+++ b/imageroot/actions/configure-module/20config
@@ -9,45 +9,7 @@ import json
 import sys
 import os
 import agent
-import agent.ldapproxy
 import subprocess
-
-def domain_setup(mail_domain, user_domain):
-    user_domain_uri = "ldapneth://accountprovider" + ":" + user_domain["port"]
-    user_domain_admin = user_domain["bind_dn"]
-
-    user_domain_password = subprocess.check_output(
-        [
-            'podman', 'run', '--replace', '--name', 'webtop-pass-encode', '--rm', '-i', os.environ["WEBTOP_WEBAPP_IMAGE"],
-            "java", "-classpath", "/usr/share/webtop/", "WebtopPassEncode"
-        ],
-        input=user_domain["bind_password"],
-        text=True
-    ).strip()
-
-    user_domain_parameters = {
-            "loginDn": user_domain["base_dn"],
-            "loginFilter": None,
-            "userDn": user_domain["base_dn"],
-            "userFilter": None,
-            "userIdField": "uid",
-            "userFirstnameField": "givenName",
-            "userLastnameField": "sn",
-            "userDisplayNameField": "displayName",
-            }
-
-    if user_domain["schema"] == "ad":
-        user_domain_parameters["loginFilter"] = "&(objectCategory=person)(objectClass=user)"
-        user_domain_parameters["userIdField"] = "sAMAccountName"
-        user_domain_parameters["userFilter"] = "(&(objectClass=user)(objectCategory=person)(!(isCriticalSystemObject=TRUE)))"
-        user_domain_parameters["userDisplayNameField"] = "displayName"
-
-    with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-U', 'postgres', 'webtop5'], stdin=subprocess.PIPE, text=True) as psql:
-        print("DELETE FROM core.domains WHERE domain_id = 'NethServer';\n", file=psql.stdin)
-        print("INSERT INTO core.domains (domain_id, internet_name, enabled, description, user_auto_creation, dir_uri, dir_admin, dir_password, dir_connection_security, dir_case_sensitive, dir_password_policy, dir_parameters) VALUES ('NethServer', '" + mail_domain + "', 't', 'NethServer', 't', '" + user_domain_uri + "', '" + user_domain_admin + "', '" + user_domain_password + "', null, 'f', 'f', '" + json.dumps(user_domain_parameters) + "');\n", file=psql.stdin)
-
-        agent.set_env("USER_DOMAIN_PORT", user_domain["port"])
-
 
 # Try to parse the stdin as JSON.
 # If parsing fails, output everything to stderr
@@ -265,23 +227,12 @@ if "mail_module" in data and "mail_domain" in data:
 
         agent.assert_exp(psql.returncode == 0) # check the command is succesfull
 
-        user_domain_name = rdb.hget(f"module/{mail_module}/srv/tcp/imap", "user_domain") or ""
-        # Bind the new domain, overriding previous values (unbind)
-        agent.bind_user_domains([user_domain_name])
-        user_domain = agent.ldapproxy.Ldapproxy().get_domain(user_domain_name) or {}
-        domain_setup(mail_domain, user_domain)
         agent.set_env("MAIL_MODULE", mail_module)
         agent.set_env("MAIL_DOMAIN", mail_domain)
         agent.set_env("RESTART_WEBAPP", "1")
 
-# In case of module move/migrate/restore, check if the port of local the ldapproxy is changed
+# In case of module move/migrate/restore, restart webtop
 if "MAIL_MODULE" in os.environ and ("mail_module" not in data or data["mail_module"] == os.getenv("MAIL_MODULE")) :
-    user_domain_name = rdb.hget(f'module/{data["mail_module"]}/srv/tcp/imap', "user_domain") or ""
-    user_domain = agent.ldapproxy.Ldapproxy().get_domain(user_domain_name) or {}
-
-    if user_domain["port"] != os.environ["USER_DOMAIN_PORT"]:
-        agent.bind_user_domains([user_domain_name])
-        domain_setup(user_domain_name, user_domain)
         agent.set_env("RESTART_WEBAPP", "1")
 
 if "webapp" in data:

--- a/imageroot/bin/discover-ldap
+++ b/imageroot/bin/discover-ldap
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import os
+import agent
+import agent.ldapproxy
+import subprocess
+import sys
+
+#
+# Find settings for LDAP service
+#
+
+# due to early start before the environment is set see ../actions/configure-module/15start_service
+# we exit if the MAIL_MODULE is not set
+if not os.environ.get("MAIL_MODULE"):
+    sys.exit(0)
+
+rdb = agent.redis_connect()
+
+def domain_setup(mail_domain, user_domain):
+    user_domain_uri = "ldapneth://accountprovider" + ":" + user_domain["port"]
+    user_domain_admin = user_domain["bind_dn"]
+
+    user_domain_password = subprocess.check_output(
+        [
+            'podman', 'run', '--replace', '--name', 'webtop-pass-encode', '--rm', '-i', os.environ["WEBTOP_WEBAPP_IMAGE"],
+            "java", "-classpath", "/usr/share/webtop/", "WebtopPassEncode"
+        ],
+        input=user_domain["bind_password"],
+        text=True
+    ).strip()
+
+    user_domain_parameters = {
+            "loginDn": user_domain["base_dn"],
+            "loginFilter": None,
+            "userDn": user_domain["base_dn"],
+            "userFilter": None,
+            "userIdField": "uid",
+            "userFirstnameField": "givenName",
+            "userLastnameField": "sn",
+            "userDisplayNameField": "displayName",
+            }
+
+    if user_domain["schema"] == "ad":
+        user_domain_parameters["loginFilter"] = "&(objectCategory=person)(objectClass=user)"
+        user_domain_parameters["userIdField"] = "sAMAccountName"
+        user_domain_parameters["userFilter"] = "(&(objectClass=user)(objectCategory=person)(!(isCriticalSystemObject=TRUE)))"
+        user_domain_parameters["userDisplayNameField"] = "displayName"
+
+    with subprocess.Popen(['podman', 'exec', '-i', 'postgres', 'psql', '-U', 'postgres', 'webtop5'], stdin=subprocess.PIPE, text=True) as psql:
+        print("DELETE FROM core.domains WHERE domain_id = 'NethServer';\n", file=psql.stdin)
+        print("INSERT INTO core.domains (domain_id, internet_name, enabled, description, user_auto_creation, dir_uri, dir_admin, dir_password, dir_connection_security, dir_case_sensitive, dir_password_policy, dir_parameters) VALUES ('NethServer', '" + mail_domain + "', 't', 'NethServer', 't', '" + user_domain_uri + "', '" + user_domain_admin + "', '" + user_domain_password + "', null, 'f', 'f', '" + json.dumps(user_domain_parameters) + "');\n", file=psql.stdin)
+
+        agent.set_env("USER_DOMAIN_PORT", user_domain["port"])
+
+
+user_domain_name = rdb.hget(f'module/{os.environ["MAIL_MODULE"]}/srv/tcp/imap', "user_domain") or ""
+user_domain = agent.ldapproxy.Ldapproxy().get_domain(user_domain_name) or {
+        'host': '127.0.0.1',
+        'port': 20000,
+        'schema': 'rfc2307',
+        'location': 'internal',
+        'base_dn': 'dc=webtop,dc=invalid',
+        'bind_dn': 'cn=example,dc=webtop,dc=invalid',
+        'bind_password': 'invalid',
+    }
+
+domain_setup(user_domain_name, user_domain)
+
+if user_domain_name and user_domain['bind_password'] != 'invalid':
+    agent.bind_user_domains([user_domain_name])

--- a/imageroot/systemd/user/webapp.service
+++ b/imageroot/systemd/user/webapp.service
@@ -15,6 +15,7 @@ WorkingDirectory=%S/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/webapp.pid %t/webapp.ctr-id
 ExecStartPre=/usr/local/bin/runagent %S/scripts/expandconfig-webapp
+ExecStartPre=/usr/local/bin/runagent discover-ldap
 ExecStart=/usr/bin/podman run \
     --env=CATALINA_OPTS="-server -Xms${WEBAPP_MIN_MEMORY}m -Xmx${WEBAPP_MAX_MEMORY}m \
                          -Djava.security.egd=file:/dev/./urandom -Dfile.encoding=UTF8 \


### PR DESCRIPTION
Implement LDAP autodiscovery functionality and ensure the web application restarts to apply the new configuration. This includes updates to the service files and the addition of a new script for LDAP discovery.

https://github.com/NethServer/dev/issues/7103
https://github.com/NethServer/dev/issues/7182

what is tested and workable

1. new module installation
2. migration from NS7
3. new mail server from the settings page
4. change of the ldap account of the mail server, propagated to webtop
