### PR TITLE
fix(ldap-discovery): use mail domain for user auth

### DIFF
--- a/imageroot/bin/discover-ldap
+++ b/imageroot/bin/discover-ldap
@@ -71,7 +71,7 @@ user_domain = agent.ldapproxy.Ldapproxy().get_domain(user_domain_name) or {
         'bind_password': 'invalid',
     }
 
-domain_setup(user_domain_name, user_domain)
+domain_setup(os.getenv("MAIL_DOMAIN"), user_domain)
 
 if user_domain_name and user_domain['bind_password'] != 'invalid':
     agent.bind_user_domains([user_domain_name])


### PR DESCRIPTION
Like it in NS7, the user should use the mail domain for authentication. Example:

- mail domain: nethserver.org
- user domain associated to mail server: ad.nethserver.org

The user should be able to authenticate using user@nethserver.org

This is a regression for NethServer/dev#7182 caused by PR #96.
Before the regression, the LDAP configuration was correct when done inside the configure-module at [this line](https://github.com/NethServer/ns8-webtop/pull/96/files#diff-7d35726f8844e7beb764a7aa7daadebaced69ba1b0c0835686183770e1e9de96L272), *but* was already wrong when executed on change of the associated mail server implemented in [this line](https://github.com/NethServer/ns8-webtop/pull/96/files#diff-7d35726f8844e7beb764a7aa7daadebaced69ba1b0c0835686183770e1e9de96L284).
So the wrong code was reported inside ldap-discovery.

In the end, the ldap-discovery code must always use the mail domain for the configuration and not the user domain.