### PR TITLE
Add RAM availability to configuration and settings

### DIFF
--- a/imageroot/actions/get-defaults/20readconfig
+++ b/imageroot/actions/get-defaults/20readconfig
@@ -48,10 +48,20 @@ for key in agent.list_service_providers(rdb,'xmpp','tcp'):
     }
     ejabberd.append(obj)
 
+# determine the amount of RAM available on the system
+try:
+    with open('/proc/meminfo', 'r') as f:
+        for line in f:
+            if line.startswith('MemTotal:'):
+                ram_mb = int(line.split()[1]) // 1024  # Convert kB to MB
+except Exception:
+    ram_mb = 4096
+
 config={
         "mail_modules_id": modules,
         "ejabberd_modules_id": ejabberd,
-        "accepted_timezone_list": list_of_timezone_widget
+        "accepted_timezone_list": list_of_timezone_widget,
+        "ram_mb": ram_mb,
         }
 
 json.dump(config, fp=sys.stdout)

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -209,7 +209,7 @@
                     v-model="webapp.min_memory"
                     :label="$t('settings.min_webapp_memory')"
                     min="256"
-                    max="4096"
+                    :max="ram_mb"
                     step="1"
                     stepMultiplier="1023"
                     minLabel=""
@@ -230,7 +230,7 @@
                     v-model="webapp.max_memory"
                     :label="$t('settings.max_webapp_memory')"
                     min="256"
-                    max="4096"
+                    :max="ram_mb"
                     step="1"
                     stepMultiplier="1023"
                     minLabel=""
@@ -430,6 +430,7 @@ export default {
       ejabberd_domain: "",
       ejabberd_modules_id: [],
       accepted_timezone_list: [],
+      ram_mb: "4096",
       locale: "",
       timezone: "",
       webapp: {
@@ -556,6 +557,7 @@ export default {
         value: "-",
       });
       this.accepted_timezone_list = config.accepted_timezone_list;
+      this.ram_mb = String(config.ram_mb);
       this.getConfiguration();
       this.loading.getDefaults = false;
     },


### PR DESCRIPTION
Include RAM availability in the configuration output and dynamically adjust the maximum memory settings based on the available RAM.

![image](https://github.com/user-attachments/assets/b51dccd5-7bfd-43f4-906e-d376bec8ec4d)

https://github.com/NethServer/dev/issues/7231