### PR TITLE
fix(pecbrdige): make sure mailnode is refreshed

### DIFF
--- a/imageroot/actions/configure-module/20config
+++ b/imageroot/actions/configure-module/20config
@@ -230,6 +230,7 @@ if "mail_module" in data and "mail_domain" in data:
         agent.set_env("MAIL_MODULE", mail_module)
         agent.set_env("MAIL_DOMAIN", mail_domain)
         agent.set_env("RESTART_WEBAPP", "1")
+        agent.set_env("RESTART_POD", "1")
 
 # In case of module move/migrate/restore, restart webtop
 if "MAIL_MODULE" in os.environ and ("mail_module" not in data or data["mail_module"] == os.getenv("MAIL_MODULE")) :

--- a/imageroot/actions/configure-module/70restart_components
+++ b/imageroot/actions/configure-module/70restart_components
@@ -12,17 +12,22 @@ restart_webapp = os.environ.get('RESTART_WEBAPP','')
 restart_webdav = os.environ.get('RESTART_WEBDAV','')
 restart_z_push = os.environ.get('RESTART_Z_PUSH','')
 restart_pec_bridge = os.environ.get('RESTART_PEC_BRIDGE','')
+restart_pod = os.environ.get('RESTART_POD','')
 
-if restart_webapp == '1':
-    agent.run_helper('systemctl','--user','restart','webapp').check_returncode()
-if restart_webdav == '1':
-    agent.run_helper('systemctl','--user','restart','webdav').check_returncode()
-if restart_z_push == '1':
-    agent.run_helper('systemctl','--user','restart','z-push').check_returncode()
-if restart_pec_bridge == '1':
-    agent.run_helper('systemctl','--user','restart','pecbridge').check_returncode()
+if restart_pod == '1':
+    agent.run_helper('systemctl','--user','restart','webtop').check_returncode()
+else:
+    if restart_webapp == '1':
+        agent.run_helper('systemctl','--user','restart','webapp').check_returncode()
+    if restart_webdav == '1':
+        agent.run_helper('systemctl','--user','restart','webdav').check_returncode()
+    if restart_z_push == '1':
+        agent.run_helper('systemctl','--user','restart','z-push').check_returncode()
+    if restart_pec_bridge == '1':
+        agent.run_helper('systemctl','--user','restart','pecbridge').check_returncode()
 
 agent.unset_env("RESTART_WEBAPP")
 agent.unset_env("RESTART_WEBDAV")
 agent.unset_env("RESTART_Z_PUSH")
 agent.unset_env("RESTART_PEC_BRIDGE")
+agent.unset_env("RESTART_POD")


### PR DESCRIPTION
The mailnode host is updated only on pod restart.
To avoid the issue, restart the pod when needed.

Alternative implementation to #112

Reference: NethServer/dev#7378