### PR TITLE
fix(phonebook): use UUIDv1 as contact_id

### DIFF
--- a/phonebook/pbook2webtop.php
+++ b/phonebook/pbook2webtop.php
@@ -211,8 +211,10 @@ function generateUUIDv1() {
     $node = bin2hex(random_bytes(6));
 
     // Construct the UUID string
+    // Standard format: %08s-%04s-%04s-%04x-%012s
+    // WebTop format, without hyphens
     return sprintf(
-        '%08s-%04s-%04s-%04x-%012s',
+        '%08s%04s%04s%04x%012s',
         $timeLow,
         $timeMid,
         $timeHighAndVersion,


### PR DESCRIPTION
Since WebTop 5.28.1 contacts do not use numeric
id anymore

To test it:
```
api-cli run update-module --data '{"module_url": "ghcr.io/nethserver/webtop:fix_phonebook_sync", "instances": ["webtop1"], "force": true}'
```

Waiting for fix on WebTop to make it work.
Current issue:
```
May 04 23:00:17 rl1 postgres[995130]: ERROR:  record "new" is not assigned yet
May 04 23:00:17 rl1 postgres[995130]: DETAIL:  The tuple structure of a not-yet-assigned record is indeterminate.
May 04 23:00:17 rl1 postgres[995130]: CONTEXT:  SQL statement "INSERT INTO "contacts"."history_contacts" ("category_id", "contact_id", "change_timestamp", "change_type")                 VAL>
May 04 23:00:17 rl1 postgres[995130]:         PL/pgSQL function contacts.update_contacts_history() line 1 at SQL statement
May 04 23:00:17 rl1 postgres[995130]: STATEMENT:  DELETE from contacts.contacts where category_id='3';
```

To manually fix it and try the PR:
```
runagent -m webtop1
podman exec -ti -u postgres postgres psql webtop5
```

Then execute this query:
```
CREATE OR REPLACE FUNCTION "contacts"."update_contacts_history"()
  RETURNS "pg_catalog"."trigger" AS $BODY$BEGIN
    IF TG_OP = 'DELETE' THEN
        INSERT INTO "contacts"."history_contacts" ("category_id", "contact_id", "change_timestamp", "change_type")
        VALUES (OLD."category_id", OLD."contact_id", NOW(), 'D');
        RETURN OLD;
    ELSIF TG_OP = 'INSERT' THEN
        INSERT INTO "contacts"."history_contacts" ("category_id", "contact_id", "change_timestamp", "change_type")
        VALUES (NEW."category_id", NEW."contact_id", NEW."revision_timestamp", 'C');
        RETURN NEW;
    ELSIF TG_OP = 'UPDATE' THEN
        IF NEW."category_id" <> OLD."category_id" THEN
            INSERT INTO "contacts"."history_contacts" ("category_id", "contact_id", "change_timestamp", "change_type")
            VALUES
            (OLD."category_id", NEW."contact_id", NEW."revision_timestamp", 'D'),
            (NEW."category_id", NEW."contact_id", NEW."revision_timestamp", 'C');
        ELSIF NEW."revision_status" <> OLD."revision_status" AND NEW."revision_status" = 'D' THEN
            INSERT INTO "contacts"."history_contacts" ("category_id", "contact_id", "change_timestamp", "change_type")
            VALUES (NEW."category_id", NEW."contact_id", NEW."revision_timestamp", 'D');
        ELSE
            INSERT INTO "contacts"."history_contacts" ("category_id", "contact_id", "change_timestamp", "change_type")
            VALUES (NEW."category_id", NEW."contact_id", NEW."revision_timestamp", 'U');
        END IF;
        RETURN NEW;
    END IF;
END$BODY$
  LANGUAGE plpgsql VOLATILE
  COST 100;
```

See https://github.com/nethserver/dev/issues/7415