### PR TITLE
chore: bump postgres to 17.5

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -84,7 +84,7 @@ images+=("${repobase}/${reponame}")
 
 #Create webtop-postgres container
 reponame="webtop-postgres"
-container=$(buildah from docker.io/library/postgres:9.2)
+container=$(buildah from docker.io/library/postgres:17.5)
 buildah add ${container} ${PWD}/webtop5-build/sql-scripts-$webtop_version.tar.gz /docker-entrypoint-initdb.d/
 buildah add ${container} ${PWD}/postgres/data /docker-entrypoint-initdb.d/data
 buildah add ${container} ${PWD}/postgres/postgres /docker-entrypoint-initdb.d/postgres


### PR DESCRIPTION
Use next stable release with longest life

See https://endoflife.date/postgresql