### PR TITLE
Update url of documentation

### DIFF
--- a/ui/public/metadata.json
+++ b/ui/public/metadata.json
@@ -12,7 +12,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "http://www.sonicle.com/webtop-5/",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/webtop.html",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/NethServer/ns8-webtop"
   },


### PR DESCRIPTION
This pull request updates the documentation URL in the `ui/public/metadata.json` file to point to the latest and more relevant documentation for the project.

* Updated the `documentation_url` in `ui/public/metadata.json` to `https://docs.nethserver.org/projects/ns8/en/latest/webtop.html` to reflect the latest documentation location

NethServer/dev#7399