### PR TITLE
Set a minimum version to 1.4.4 for postgresql upgrade

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -182,6 +182,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=traefik@node:routeadm mail@any:mailadm cluster:accountconsumer nethvoice@any:pbookreader" \
     --label="org.nethserver.tcp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
+    --label="org.nethserver.min-from=1.4.3" \
     --label="org.nethserver.images=${repobase}/webtop-webapp:${IMAGETAG:-latest} \
     ${repobase}/webtop-postgres:${IMAGETAG:-latest} \
     ${repobase}/webtop-apache:${IMAGETAG:-latest} \

--- a/build-images.sh
+++ b/build-images.sh
@@ -182,7 +182,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=traefik@node:routeadm mail@any:mailadm cluster:accountconsumer nethvoice@any:pbookreader" \
     --label="org.nethserver.tcp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.min-from=1.4.3" \
+    --label="org.nethserver.min-from=1.4.4" \
     --label="org.nethserver.images=${repobase}/webtop-webapp:${IMAGETAG:-latest} \
     ${repobase}/webtop-postgres:${IMAGETAG:-latest} \
     ${repobase}/webtop-apache:${IMAGETAG:-latest} \


### PR DESCRIPTION
This pull request introduces a small change to the `build-images.sh` script, adding a new label to the container configuration.  Minimum version to 1.4.3 for postgresql upgrade

https://github.com/NethServer/dev/issues/7489