### PR TITLE
fix: min-from any version

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -183,7 +183,6 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=traefik@node:routeadm mail@any:mailadm cluster:accountconsumer nethvoice@any:pbookreader" \
     --label="org.nethserver.tcp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.min-from=1.4.4" \
     --label="org.nethserver.images=${repobase}/webtop-webapp:${IMAGETAG:-latest} \
     ${repobase}/webtop-postgres:${IMAGETAG:-latest} \
     ${repobase}/webtop-apache:${IMAGETAG:-latest} \


### PR DESCRIPTION
PostgreSQL 17 upgrade procedure works from any past release of Webtop, that are based on PG 9.


Refs NethServer/dev#7489