### PR TITLE
Enable additional proxy and rewrite modules in Apache configuration

### DIFF
--- a/apache/httpd.conf
+++ b/apache/httpd.conf
@@ -143,11 +143,11 @@ LoadModule proxy_module modules/mod_proxy.so
 #LoadModule proxy_connect_module modules/mod_proxy_connect.so
 #LoadModule proxy_ftp_module modules/mod_proxy_ftp.so
 LoadModule proxy_http_module modules/mod_proxy_http.so
-#LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
+LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
 #LoadModule proxy_scgi_module modules/mod_proxy_scgi.so
 #LoadModule proxy_uwsgi_module modules/mod_proxy_uwsgi.so
 #LoadModule proxy_fdpass_module modules/mod_proxy_fdpass.so
-#LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
+LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
 #LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
 #LoadModule proxy_balancer_module modules/mod_proxy_balancer.so
 #LoadModule proxy_express_module modules/mod_proxy_express.so
@@ -196,7 +196,7 @@ LoadModule dir_module modules/mod_dir.so
 #LoadModule speling_module modules/mod_speling.so
 #LoadModule userdir_module modules/mod_userdir.so
 LoadModule alias_module modules/mod_alias.so
-#LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule rewrite_module modules/mod_rewrite.so
 
 <IfModule unixd_module>
 #


### PR DESCRIPTION
Activate previously commented-out proxy and rewrite modules in the Apache configuration to enhance functionality.

https://github.com/NethServer/dev/issues/7605

the list of needed module comes from https://github.com/NethServer/ns8-webtop/tree/main/apache/vhosts