### PR TITLE
Update Apache configuration for HTTPS redirection and host preservation

### DIFF
--- a/apache/vhosts/webapp.conf
+++ b/apache/vhosts/webapp.conf
@@ -13,8 +13,6 @@ RedirectRelative on
 
 # Force https location answer of apache
 Header edit Location "^http://(.*)$" "https://$1"
-
-ProxyAddHeaders On
 ProxyPreserveHost On
 ProxyPass /webtop/push ws://127.0.0.1:8080/webtop/push
 ProxyPassReverse /webtop/push ws://127.0.0.1:8080/webtop/push


### PR DESCRIPTION
Ensure that the root URL always redirects to HTTPS while preserving the original host and protocol in the Apache configuration.

https://github.com/NethServer/dev/issues/7547

when you try the url https://webtop.rocky9-pve.org you hit the apache redirection, the first one get a location to 


`Location http://webtop.rocky9-pve.org/webtop/`


<img width="1917" height="908" alt="image" src="https://github.com/user-attachments/assets/6ddfe626-3f91-4d66-9cfb-41e430549530" />

we force the header location to https, the location becomes

 `location https://webtop.rocky9-pve.org/webtop/`






<img width="1917" height="908" alt="image" src="https://github.com/user-attachments/assets/5b7ef26b-07fd-4cf9-aa9e-17fda9d78fd9" />
