### PR TITLE
fix: allow IANA-compatible timezones

### DIFF
--- a/webtop5-build/ListTimeZones.java
+++ b/webtop5-build/ListTimeZones.java
@@ -14,7 +14,7 @@ public class ListTimeZones {
     // Valid IANA areas as defined in the IANA Time Zone Database
     private static final Set<String> VALID_IANA_AREAS = new HashSet<>(Arrays.asList(
         "Africa",
-        "America", 
+        "America",
         "Antarctica",
         "Arctic",
         "Asia",


### PR DESCRIPTION
Since PostgreSQL 17, only IANA timezones are allowed.

Filter out any JVM timezone code that is not prefixed with an IANA Area prefix.

Refs NethServer/dev#7630