### PR TITLE
fix(systemd): replace %S with %E in unit files

### DIFF
--- a/imageroot/systemd/user/apache.service
+++ b/imageroot/systemd/user/apache.service
@@ -8,8 +8,8 @@ PartOf=webtop.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/apache.pid %t/apache.ctr-id
 ExecStartPre=/usr/bin/mkdir -vp autoconfiguration

--- a/imageroot/systemd/user/pecbridge.service
+++ b/imageroot/systemd/user/pecbridge.service
@@ -6,8 +6,8 @@ After=webapp.service
 [Service]
 Type=forking
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/pecbridge.pid %t/pecbridge.ctr-id
 ExecStart=/usr/bin/podman run \

--- a/imageroot/systemd/user/phonebook.service
+++ b/imageroot/systemd/user/phonebook.service
@@ -4,8 +4,8 @@ After=postgres.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 ExecStartPre=/bin/rm -f %t/%N.pid %t/%N.ctr-id
 ExecStart=runagent podman run \
     --env-file=./phonebook.env \

--- a/imageroot/systemd/user/postgres.service
+++ b/imageroot/systemd/user/postgres.service
@@ -10,8 +10,8 @@ After=webtop.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 # wait-postgres-init should complete in 5 minutes,
 # this sets an larger safeguard limit:

--- a/imageroot/systemd/user/webapp.service
+++ b/imageroot/systemd/user/webapp.service
@@ -10,11 +10,11 @@ PartOf=webtop.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/webapp.pid %t/webapp.ctr-id
-ExecStartPre=/usr/local/bin/runagent %S/scripts/expandconfig-webapp
+ExecStartPre=/usr/local/bin/runagent %E/scripts/expandconfig-webapp
 ExecStartPre=/usr/local/bin/runagent discover-ldap
 ExecStartPre=/usr/local/bin/runagent mkdir -p webtop-custom-jars
 ExecStart=/usr/bin/podman run \

--- a/imageroot/systemd/user/webdav.service
+++ b/imageroot/systemd/user/webdav.service
@@ -9,11 +9,11 @@ PartOf=webtop.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/%N.pid %t/%N.ctr-id
-ExecStartPre=%S/scripts/expandconfig-webdav
+ExecStartPre=%E/scripts/expandconfig-webdav
 ExecStart=/usr/bin/podman run \
     --pod=webtop \
     --detach \

--- a/imageroot/systemd/user/webtop.service
+++ b/imageroot/systemd/user/webtop.service
@@ -9,8 +9,8 @@ Before=webapp.service postgres.service apache.service webdav.service z-push.serv
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/webtop.pid %t/webtop.pod-id
 ExecStartPre=/usr/bin/podman pod create \

--- a/imageroot/systemd/user/z-push.service
+++ b/imageroot/systemd/user/z-push.service
@@ -9,11 +9,11 @@ PartOf=webtop.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/%N.pid %t/%N.ctr-id
-ExecStartPre=%S/scripts/expandconfig-z-push
+ExecStartPre=%E/scripts/expandconfig-z-push
 ExecStart=/usr/bin/podman run \
     --pod=webtop \
     --detach \


### PR DESCRIPTION
## Summary
- Newer systemd releases (Rocky Linux 9.8+, Debian 13) changed the `%S` specifier to expand to `~/.local/state` instead of `~/.config`, breaking units that relied on the old behavior to reference the config/state directory.
- Replaced `%S` with `%E` across all affected systemd user unit files. `%E` expands to `~/.config` on both old and new systemd, making the units forward-compatible.

Related: NethServer/dev#8029

## Test plan
- [ ] Verify units still parse (`systemd-analyze verify`) on a test node
- [ ] Confirm services start correctly on both an old (Rocky 9.x pre-9.8) and new (Rocky 9.8+/Debian 13) systemd host